### PR TITLE
Add Result type

### DIFF
--- a/src/Larkins.CSharpKatas/ResultType/Result.cs
+++ b/src/Larkins.CSharpKatas/ResultType/Result.cs
@@ -1,0 +1,24 @@
+namespace Larkins.CSharpKatas.ResultType;
+
+public partial record Result
+{
+    private readonly string? error;
+
+    private Result(bool isSuccess, string? error = default)
+    {
+        IsSuccess = isSuccess;
+        this.error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public string Error => IsFailure
+        ? error!
+        : throw new InvalidOperationException("This is a success result. There is no Error.");
+
+    public static Result Success() => new(true);
+
+    public static Result Failure(string errorMessage) => new(false, errorMessage);
+}

--- a/src/Larkins.CSharpKatas/ResultType/ResultT.cs
+++ b/src/Larkins.CSharpKatas/ResultType/ResultT.cs
@@ -1,0 +1,52 @@
+namespace Larkins.CSharpKatas.ResultType;
+
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType
+#pragma warning disable SA1649 // FileNameMustMatchTypeName
+public record Result<T>
+#pragma warning restore SA1649 // FileNameMustMatchTypeName
+{
+    private readonly T? value;
+    private readonly string? error;
+
+    // The reason that `default` doesn't just provide null is because the generic type T
+    // could be either a class or a struct. There is ongoing discussion around this:
+    // https://github.com/dotnet/csharplang/discussions/2194
+    // The work-around used here is to ignore the provided value and set it to null if
+    // isSuccess is false.
+    internal Result(bool isSuccess, T? value, string? error)
+    {
+        IsSuccess = isSuccess;
+        this.value = value;
+        this.error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public T Value => IsSuccess
+        ? value!
+        : throw new InvalidOperationException("This is a failure result. There is no Value.");
+
+    public string Error => IsFailure
+        ? error!
+        : throw new InvalidOperationException("This is a success result. There is no Error.");
+
+    public static implicit operator Result<T>(T value) => Result.Success(value);
+}
+
+public partial record Result
+{
+    public static Result<T> Success<T>(T value)
+        => new(
+        isSuccess: true,
+        value: value,
+        error: default);
+
+    public static Result<T> Failure<T>(string errorMessage)
+        => new(
+        isSuccess: false,
+        value: default,
+        error: errorMessage);
+}
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType

--- a/src/Larkins.CSharpKatas/ResultType/ResultTE.cs
+++ b/src/Larkins.CSharpKatas/ResultType/ResultTE.cs
@@ -1,0 +1,45 @@
+namespace Larkins.CSharpKatas.ResultType;
+
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType
+#pragma warning disable SA1649 // FileNameMustMatchTypeName
+public record Result<T, TError>
+#pragma warning restore SA1649 // FileNameMustMatchTypeName
+{
+    private readonly T? value;
+    private readonly TError? error;
+
+    internal Result(bool isSuccess, T? value, TError? error)
+    {
+        IsSuccess = isSuccess;
+        this.error = error;
+        this.value = value;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public T Value => IsSuccess
+        ? value!
+        : throw new InvalidOperationException("This is a failure result. There is no Value.");
+
+    public TError Error => IsFailure
+        ? error!
+        : throw new InvalidOperationException("This is a success result. There is no Error.");
+
+    public static implicit operator Result<T, TError>(T value) => Result.Success<T, TError>(value);
+}
+
+public partial record Result
+{
+    public static Result<T, TError> Success<T, TError>(T value) => new(
+        isSuccess: true,
+        value: value,
+        error: default);
+
+    public static Result<T, TError> Failure<T, TError>(TError error) => new(
+        isSuccess: false,
+        value: default,
+        error: error);
+}
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType

--- a/src/Larkins.CSharpKatas/ResultType/UnitResult.cs
+++ b/src/Larkins.CSharpKatas/ResultType/UnitResult.cs
@@ -1,0 +1,36 @@
+namespace Larkins.CSharpKatas.ResultType;
+
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType
+public record UnitResult<TError>
+{
+    private readonly TError? error;
+
+    internal UnitResult(bool isSuccess, TError? error = default)
+    {
+        IsSuccess = isSuccess;
+        this.error = error;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public TError Error => IsFailure
+        ? error!
+        : throw new InvalidOperationException("This is a success result. There is no Error.");
+
+    public static implicit operator UnitResult<TError>(TError error) => UnitResult.Failure(error);
+}
+
+/// <summary>
+/// This UnitResult class is only here so that a UnitResult&lt;TError&gt; can be created by going
+/// UnitResult.Failure(MyError) instead of having to go UnitResult&lt;MyError&gt;.Failure(MyError).
+/// </summary>
+public static class UnitResult
+{
+    public static UnitResult<TError> Success<TError>() => new(true);
+
+    public static UnitResult<TError> Failure<TError>(TError error)
+        => new(false, error);
+}
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType

--- a/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultBehaviours.cs
+++ b/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultBehaviours.cs
@@ -1,0 +1,50 @@
+using FluentAssertions.Execution;
+using Larkins.CSharpKatas.ResultType;
+
+namespace Larkins.CSharpKatas.Tests.Unit.ResultType;
+
+public class ResultBehaviours
+{
+    [Fact]
+    public void Success_result_conveys_its_success()
+    {
+        var sut = Result.Success();
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeTrue();
+            sut.IsFailure.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Success_result_does_not_contain_error_message()
+    {
+        var sut = Result.Success();
+
+        sut.Invoking(result => result.Error)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a success result. There is no Error.");
+    }
+
+    [Fact]
+    public void Failure_result_conveys_its_failure()
+    {
+        var sut = Result.Failure(string.Empty);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeFalse();
+            sut.IsFailure.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void Failure_result_contains_error_message()
+    {
+        var errorMessage = "Failed result.";
+        var sut = Result.Failure(errorMessage);
+
+        sut.Error.Should().Be(errorMessage);
+    }
+}

--- a/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultTBehaviours.cs
+++ b/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultTBehaviours.cs
@@ -1,0 +1,81 @@
+using FluentAssertions.Execution;
+using Larkins.CSharpKatas.ResultType;
+
+namespace Larkins.CSharpKatas.Tests.Unit.ResultType;
+
+public class ResultTBehaviours
+{
+    [Fact]
+    public void Success_result_conveys_its_success()
+    {
+        var successValue = 100;
+        var sut = Result.Success(successValue);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeTrue();
+            sut.IsFailure.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Success_result_does_not_contain_error()
+    {
+        var successValue = 100;
+        var sut = Result.Success(successValue);
+
+        sut.Invoking(result => result.Error)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a success result. There is no Error.");
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData("Success")]
+    public void Success_result_contains_value<T>(T successValue)
+    {
+        var sut = Result.Success(successValue);
+
+        sut.Value.Should().Be(successValue);
+    }
+
+    [Fact]
+    public void Success_result_can_be_implicitly_converted_from_type()
+    {
+        var successValue = 100;
+        Result<int> sut = successValue;
+
+        sut.Value.Should().Be(successValue);
+    }
+
+    [Fact]
+    public void Failure_result_conveys_its_failure()
+    {
+        var sut = Result.Failure<int>(string.Empty);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeFalse();
+            sut.IsFailure.Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void Failure_result_contains_error_message()
+    {
+        var errorMessage = "Failed result.";
+        var sut = Result.Failure<int>(errorMessage);
+
+        sut.Error.Should().Be(errorMessage);
+    }
+
+    [Fact]
+    public void Failure_result_does_not_contain_value()
+    {
+        var sut = Result.Failure<int>(string.Empty);
+
+        sut.Invoking(result => result.Value)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a failure result. There is no Value.");
+    }
+}

--- a/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultTEBehaviours.cs
+++ b/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/ResultTEBehaviours.cs
@@ -1,0 +1,83 @@
+using FluentAssertions.Execution;
+using Larkins.CSharpKatas.ResultType;
+
+namespace Larkins.CSharpKatas.Tests.Unit.ResultType;
+
+public class ResultTEBehaviours
+{
+    [Fact]
+    public void Success_result_conveys_its_success()
+    {
+        var successValue = 100;
+        var sut = Result.Success<int, int>(successValue);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeTrue();
+            sut.IsFailure.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Success_result_does_not_contain_error()
+    {
+        var successValue = 100;
+        var sut = Result.Success<int, int>(successValue);
+
+        sut.Invoking(result => result.Error)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a success result. There is no Error.");
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData("Success")]
+    public void Success_result_contains_value<T>(T successValue)
+    {
+        var sut = Result.Success<T, int>(successValue);
+
+        sut.Value.Should().Be(successValue);
+    }
+
+    [Fact]
+    public void Success_result_can_be_implicitly_converted_from_type()
+    {
+        var successValue = 100;
+        Result<int, int> sut = successValue;
+
+        sut.Value.Should().Be(successValue);
+    }
+
+    [Fact]
+    public void Failure_result_conveys_its_failure()
+    {
+        var errorValue = -1;
+        var sut = Result.Failure<int, int>(errorValue);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeFalse();
+            sut.IsFailure.Should().BeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData("Failure")]
+    public void Failure_result_contains_error<TError>(TError errorValue)
+    {
+        var sut = Result.Failure<int, TError>(errorValue);
+
+        sut.Error.Should().Be(errorValue);
+    }
+
+    [Fact]
+    public void Failure_result_does_not_contain_value()
+    {
+        var sut = Result.Failure<int, string>(string.Empty);
+
+        sut.Invoking(result => result.Value)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a failure result. There is no Value.");
+    }
+}

--- a/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/UnitResultBehaviours.cs
+++ b/tests/Larkins.CSharpKatas.Tests.Unit/ResultType/UnitResultBehaviours.cs
@@ -1,0 +1,60 @@
+using FluentAssertions.Execution;
+using Larkins.CSharpKatas.ResultType;
+
+namespace Larkins.CSharpKatas.Tests.Unit.ResultType;
+
+public class UnitResultBehaviours
+{
+    [Fact]
+    public void Success_result_conveys_its_success()
+    {
+        var sut = UnitResult.Success<string>();
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeTrue();
+            sut.IsFailure.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void Success_result_does_not_contain_error()
+    {
+        var sut = UnitResult.Success<string>();
+
+        sut.Invoking(result => result.Error)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("This is a success result. There is no Error.");
+    }
+
+    [Fact]
+    public void Failure_result_conveys_its_failure()
+    {
+        var sut = UnitResult.Failure(string.Empty);
+
+        using (new AssertionScope())
+        {
+            sut.IsSuccess.Should().BeFalse();
+            sut.IsFailure.Should().BeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData("Failure")]
+    public void Failure_result_contains_error<TError>(TError errorValue)
+    {
+        var sut = UnitResult.Failure(errorValue);
+
+        sut.Error.Should().Be(errorValue);
+    }
+
+    [Fact]
+    public void Failure_can_be_implicitly_converted_from_type()
+    {
+        var error = 100;
+        UnitResult<int> sut = error;
+
+        sut.Error.Should().Be(error);
+    }
+}


### PR DESCRIPTION
This provides the Result type rather than relying on Result from the CSharpFunctionalExtensions NuGet package. These result types are however based on the implementation used in CSharpFunctionalExtensions.