### PR TITLE
Remove CSharpFunctionalExtensions

### DIFF
--- a/src/Larkins.CSharpKatas/GlobalUsings.cs
+++ b/src/Larkins.CSharpKatas/GlobalUsings.cs
@@ -1,4 +1,3 @@
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
-global using CSharpFunctionalExtensions;

--- a/src/Larkins.CSharpKatas/Larkins.CSharpKatas.csproj
+++ b/src/Larkins.CSharpKatas/Larkins.CSharpKatas.csproj
@@ -1,7 +1,1 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.29.0" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/Larkins.CSharpKatas/RomanNumeral.cs
+++ b/src/Larkins.CSharpKatas/RomanNumeral.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Larkins.CSharpKatas.ResultType;
 
 namespace Larkins.CSharpKatas;
 

--- a/src/Larkins.CSharpKatas/TenPinBowling/ValueObjects/Roll.cs
+++ b/src/Larkins.CSharpKatas/TenPinBowling/ValueObjects/Roll.cs
@@ -1,11 +1,11 @@
-using System.Collections.Generic;
+using Larkins.CSharpKatas.ResultType;
 
 namespace Larkins.CSharpKatas.TenPinBowling.ValueObjects;
 
 /// <summary>
 /// Represents a roll where 0 to 10 pins have been knocked down.
 /// </summary>
-public class Roll : ValueObject
+public record Roll
 {
     private Roll(int pinsKnockedDown)
     {
@@ -31,14 +31,5 @@ public class Roll : ValueObject
         }
 
         return new Roll(pinsKnockedDown);
-    }
-
-    /// <summary>
-    /// Used to determine equality between Rolls.
-    /// </summary>
-    /// <returns>The components used to determine equality between rolls.</returns>
-    protected override IEnumerable<object> GetEqualityComponents()
-    {
-        yield return PinsKnockedDown;
     }
 }


### PR DESCRIPTION
As the katas now contains an implementation for Result, this can be used instead of relying on CSharpFunctionalExtensions. Record can also be used instead of ValueObject.